### PR TITLE
feat(auth): add regex validation for email and password, enforce min.…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,8 @@ db_username.txt
 .DS_Store     # MacOS
 Thumbs.db     # Windows
 backend/src/main/resources/env.properties
+backend/desktop.ini
+Babasse-Old-School-Fichiers-gif.ico
+desktop.ini
+Iconarchive-Mothers-Day-Gift.ico
+Icons-Land-3d-Food-Dish-Pasta-Spaghetti.ico

--- a/backend/src/main/java/com/mystery/project/authentication/AuthenticationService.java
+++ b/backend/src/main/java/com/mystery/project/authentication/AuthenticationService.java
@@ -8,17 +8,17 @@ import com.mystery.project.authentication.exceptions.EmailNotFoundException;
 import com.mystery.project.entities.user.Role;
 import com.mystery.project.entities.user.User;
 import com.mystery.project.entities.user.UserRepository;
+import com.mystery.project.exception.BadRequestException;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.web.context.SecurityContextRepository;
 import org.springframework.stereotype.Service;
-
-import java.util.Optional;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -27,9 +27,29 @@ public class AuthenticationService {
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
   private final AuthenticationManager authenticationManager;
+  private static final String EMAIL_REGEX = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
+  private static final Pattern emailPattern = Pattern.compile(EMAIL_REGEX);
+
+  private static final String PASSWORD_REGEX =
+      "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$";
+  private static final Pattern passwordPattern = Pattern.compile(PASSWORD_REGEX);
 
   public Authentication registerUser(RegisterRequestDto registerRequestDto) {
-    User nameCheck = userRepository.findByDisplayNameIgnoreCase(registerRequestDto.displayName()).orElse(null);
+    if (!isValidEmail(registerRequestDto.email())) {
+      throw new BadRequestException("Not a valid email address.");
+    }
+
+    if (!isValidPassword(registerRequestDto.password())) {
+      throw new BadRequestException(
+          "Password must be at least 8 characters long, contain at least one letter, one number, and one special character.");
+    }
+
+    if (registerRequestDto.displayName().length() <= 3) {
+      throw new BadRequestException("Display name should have at least 3 characters");
+    }
+
+    User nameCheck =
+        userRepository.findByDisplayNameIgnoreCase(registerRequestDto.displayName()).orElse(null);
     if (nameCheck != null) {
       throw new DuplicateDisplayNameException("Display name is taken.");
     }
@@ -40,15 +60,16 @@ public class AuthenticationService {
     }
 
     userRepository.save(
-            new User(
-                UUID.randomUUID(),
-                registerRequestDto.email(),
-                passwordEncoder.encode(registerRequestDto.password()),
-                registerRequestDto.displayName(),
-                Role.USER));
+        new User(
+            UUID.randomUUID(),
+            registerRequestDto.email(),
+            passwordEncoder.encode(registerRequestDto.password()),
+            registerRequestDto.displayName(),
+            Role.USER));
 
     Authentication authenticationToken =
-        new UsernamePasswordAuthenticationToken(registerRequestDto.email(), registerRequestDto.password());
+        new UsernamePasswordAuthenticationToken(
+            registerRequestDto.email(), registerRequestDto.password());
     return authenticationManager.authenticate(authenticationToken);
   }
 
@@ -60,6 +81,19 @@ public class AuthenticationService {
   }
 
   public User getUserByEmail(String email) {
-    return userRepository.findByEmailIgnoreCase(email).orElseThrow(()-> new EmailNotFoundException("A user with this email adress does not exist."));
+    return userRepository
+        .findByEmailIgnoreCase(email)
+        .orElseThrow(
+            () -> new EmailNotFoundException("A user with this email adress does not exist."));
+  }
+
+  public boolean isValidEmail(String email) {
+    Matcher matcher = emailPattern.matcher(email);
+    return matcher.matches();
+  }
+
+  public boolean isValidPassword(String password) {
+    Matcher matcher = passwordPattern.matcher(password);
+    return matcher.matches();
   }
 }

--- a/backend/src/main/java/com/mystery/project/authentication/AuthenticationService.java
+++ b/backend/src/main/java/com/mystery/project/authentication/AuthenticationService.java
@@ -28,11 +28,11 @@ public class AuthenticationService {
   private final AuthenticationManager authenticationManager;
 
   public Authentication registerUser(RegisterRequestDto registerRequestDto) {
-    if (!UserValidator.isValidEmail(registerRequestDto.email())) {
+    if (!UserValidator.isValidEmailPattern(registerRequestDto.email())) {
       throw new BadRequestException("Not a valid email address.");
     }
 
-    if (!UserValidator.isValidPassword(registerRequestDto.password())) {
+    if (!UserValidator.isValidPasswordPattern(registerRequestDto.password())) {
       throw new BadRequestException(
           "Password must be at least 8 characters long, contain at least one letter, one number, and one special character.");
     }

--- a/backend/src/main/java/com/mystery/project/authentication/AuthenticationService.java
+++ b/backend/src/main/java/com/mystery/project/authentication/AuthenticationService.java
@@ -27,9 +27,9 @@ public class AuthenticationService {
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
   private final AuthenticationManager authenticationManager;
+
   private static final String EMAIL_REGEX = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
   private static final Pattern emailPattern = Pattern.compile(EMAIL_REGEX);
-
   private static final String PASSWORD_REGEX =
       "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$";
   private static final Pattern passwordPattern = Pattern.compile(PASSWORD_REGEX);

--- a/backend/src/main/java/com/mystery/project/authentication/AuthenticationService.java
+++ b/backend/src/main/java/com/mystery/project/authentication/AuthenticationService.java
@@ -9,9 +9,8 @@ import com.mystery.project.entities.user.Role;
 import com.mystery.project.entities.user.User;
 import com.mystery.project.entities.user.UserRepository;
 import com.mystery.project.exception.BadRequestException;
+import com.mystery.project.util.validation.UserValidator;
 import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -28,23 +27,17 @@ public class AuthenticationService {
   private final PasswordEncoder passwordEncoder;
   private final AuthenticationManager authenticationManager;
 
-  private static final String EMAIL_REGEX = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
-  private static final Pattern emailPattern = Pattern.compile(EMAIL_REGEX);
-  private static final String PASSWORD_REGEX =
-      "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$";
-  private static final Pattern passwordPattern = Pattern.compile(PASSWORD_REGEX);
-
   public Authentication registerUser(RegisterRequestDto registerRequestDto) {
-    if (!isValidEmail(registerRequestDto.email())) {
+    if (!UserValidator.isValidEmail(registerRequestDto.email())) {
       throw new BadRequestException("Not a valid email address.");
     }
 
-    if (!isValidPassword(registerRequestDto.password())) {
+    if (!UserValidator.isValidPassword(registerRequestDto.password())) {
       throw new BadRequestException(
           "Password must be at least 8 characters long, contain at least one letter, one number, and one special character.");
     }
 
-    if (registerRequestDto.displayName().length() <= 3) {
+    if (!UserValidator.isValidDisplayName(registerRequestDto.displayName())) {
       throw new BadRequestException("Display name should have at least 3 characters");
     }
 
@@ -85,15 +78,5 @@ public class AuthenticationService {
         .findByEmailIgnoreCase(email)
         .orElseThrow(
             () -> new EmailNotFoundException("A user with this email address does not exist."));
-  }
-
-  public boolean isValidEmail(String email) {
-    Matcher matcher = emailPattern.matcher(email);
-    return matcher.matches();
-  }
-
-  public boolean isValidPassword(String password) {
-    Matcher matcher = passwordPattern.matcher(password);
-    return matcher.matches();
   }
 }

--- a/backend/src/main/java/com/mystery/project/authentication/AuthenticationService.java
+++ b/backend/src/main/java/com/mystery/project/authentication/AuthenticationService.java
@@ -84,7 +84,7 @@ public class AuthenticationService {
     return userRepository
         .findByEmailIgnoreCase(email)
         .orElseThrow(
-            () -> new EmailNotFoundException("A user with this email adress does not exist."));
+            () -> new EmailNotFoundException("A user with this email address does not exist."));
   }
 
   public boolean isValidEmail(String email) {

--- a/backend/src/main/java/com/mystery/project/util/validation/UserValidator.java
+++ b/backend/src/main/java/com/mystery/project/util/validation/UserValidator.java
@@ -1,0 +1,26 @@
+package com.mystery.project.util.validation;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class UserValidator {
+  private static final String EMAIL_REGEX = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
+  private static final Pattern emailPattern = Pattern.compile(EMAIL_REGEX);
+  private static final String PASSWORD_REGEX =
+      "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$";
+  private static final Pattern passwordPattern = Pattern.compile(PASSWORD_REGEX);
+
+  public static boolean isValidEmail(String email) {
+    Matcher matcher = emailPattern.matcher(email);
+    return matcher.matches();
+  }
+
+  public static boolean isValidPassword(String password) {
+    Matcher matcher = passwordPattern.matcher(password);
+    return matcher.matches();
+  }
+
+  public static boolean isValidDisplayName(String displayName) {
+    return displayName.length() >= 3;
+  }
+}

--- a/backend/src/main/java/com/mystery/project/util/validation/UserValidator.java
+++ b/backend/src/main/java/com/mystery/project/util/validation/UserValidator.java
@@ -10,12 +10,12 @@ public class UserValidator {
       "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$";
   private static final Pattern passwordPattern = Pattern.compile(PASSWORD_REGEX);
 
-  public static boolean isValidEmail(String email) {
+  public static boolean isValidEmailPattern(String email) {
     Matcher matcher = emailPattern.matcher(email);
     return matcher.matches();
   }
 
-  public static boolean isValidPassword(String password) {
+  public static boolean isValidPasswordPattern(String password) {
     Matcher matcher = passwordPattern.matcher(password);
     return matcher.matches();
   }


### PR DESCRIPTION
… length for display name

added regex validation to ensure email and password follow a required format. Additionally, display names must now be at least 3 characters long.

added some files to gitignore cause i wanted custom icons, which im sure nobody else wants or needs 🍩

BREAKING CHANGE: Users must provide a valid email and password during registration. Display names shorter then 3 characters are no longer allowed.